### PR TITLE
Add Grantha script

### DIFF
--- a/src/grantha.json
+++ b/src/grantha.json
@@ -1,0 +1,8 @@
+[
+  [{ "script": "ஜ்", "romanization": "j", "ipa": "d͡ʑ", "iso15919": "j" }],
+  [{ "script": "ஶ்", "romanization": "s", "ipa": "ɕ", "iso15919": "ś" }],
+  [{ "script": "ஷ்", "romanization": "s", "ipa": "ʂ", "iso15919": "ṣ" }],
+  [{ "script": "ஸ்", "romanization": "s", "ipa": "s", "iso15919": "s" }],
+  [{ "script": "ஹ்", "romanization": "h", "ipa": "h", "iso15919": "h" }],
+  [{ "script": "க்ஷ்", "romanization": "ks", "ipa": "kʂ", "iso15919": "kṣ" }]
+]

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -21,4 +21,12 @@ describe('script tests', () => {
     expect(getIPA('"";அம்!மா&&=')).toEqual('"";am!maː&&=');
     expect(getIso15919('+அம்!மா--!')).toEqual('+am!mā--!');
   });
+
+  it('takes grantha scripts into account', () => {
+    expect(getIPA('"";அம்!மாஜ்&&=')).toEqual('"";am!maːஜ்&&=');
+    expect(getIso15919('+அம்!மாஜ்--!')).toEqual('+am!māஜ்--!');
+
+    expect(getIPA('"";அம்!மாஜ்&&=', { grantha: true })).toEqual('"";am!maːd͡ʑ&&=');
+    expect(getIso15919('+அம்!மாஜ்--!', { grantha: true })).toEqual('+am!māj--!');
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import data from './script.json';
+import grantha from './grantha.json';
 
 export type Script = {
   index: number;
@@ -9,10 +10,14 @@ export type Script = {
   ipa: string;
 };
 
+export type Options = {
+  grantha: boolean;
+};
+
 export const script = data as Script[][];
 
-export const getIso15919 = (phrase: string) => {
-  const iso15919Map = script
+export const getIso15919 = (phrase: string, options?: Options) => {
+  const iso15919Map = [...script, ...(options?.grantha ? grantha : [])]
     .flat()
     .reduce(
       (scripts, newScript) => ({ ...scripts, [newScript.script]: newScript.iso15919 }),
@@ -30,8 +35,8 @@ export const getIso15919 = (phrase: string) => {
     .join(' ');
 };
 
-export const getIPA = (phrase: string) => {
-  const ipaMap = script
+export const getIPA = (phrase: string, options?: Options) => {
+  const ipaMap = [...script, ...(options?.grantha ? grantha : [])]
     .flat()
     .reduce((scripts, newScript) => ({ ...scripts, [newScript.script]: newScript.ipa }), {} as Record<string, string>);
 


### PR DESCRIPTION
This PR adds the Grantha script's consonants. The transliteration functions now have the option to include these when getting the transliteration of a word. 

## Note

We are — for now — only adding the consonants but we might want to add the whole set in the future